### PR TITLE
Options to customize backup names and clean up after backup/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,36 @@
-#mongobackup-s3
+# mongobackup-s3
 
-A simple docker container to backup mongo to s3.  Easy to integrate with cron.
+A simple docker container to backup MongoDB to S3, restore backups, and list backups.  Easy to integrate with cron.
 
 ## Usage
 
-To initiate a backup.
+### Backup
+To initiate a backup:
 
 ```
 docker run --rm --link mongo:mongo --env AWS_ACCESS_KEY_ID=123 --env AWS_SECRET_ACCESS_KEY=123 --env S3BUCKET=bucket firstandthird/mongobackup-s3
 ```
 
-To list the backups on s3.
+#### Customizing backup names
+The naming used by backups can also be customised through environment variables:
+- ``DATEFORMAT`` accepts a Unix date format. Defaults to: ``%Y%m%d_%H%M%S``
+- ``FILEPREFIX`` to add a prefix to the start of the backup's name. Defaults to blank.
+
+**Example**
+To add a file like ``mongodb.2016-02-08-03-10-20.tar.gz`` to your AWS bucket:
+```
+docker run --rm --link mongo:mongo --env DATEFORMAT=%Y-%m-%d-%H-%M-%S --env FILEPREFIX=mongodb. --env AWS_ACCESS_KEY_ID=123 --env AWS_SECRET_ACCESS_KEY=123 --env S3BUCKET=bucket firstandthird/mongobackup-s3
+```
+
+## List
+To list the backups on S3:
 
 ```
 docker run --rm --link mongo:mongo --env AWS_ACCESS_KEY_ID=123 --env AWS_SECRET_ACCESS_KEY=123 --env S3BUCKET=bucket firstandthird/mongobackup-s3 list
 ```
 
-To restore a given backup, where `[backup-file-name]` is the name of the backup file you would like to restore.
+## Restore
+To restore a given backup, where `[backup-file-name]` is the name of the backup file you would like to restore:
 
 ```
 docker run --rm --link mongo:mongo --env AWS_ACCESS_KEY_ID=123 --env AWS_SECRET_ACCESS_KEY=123 --env S3BUCKET=bucket firstandthrd/mongobackup-s3 [backup-file-name]

--- a/backup
+++ b/backup
@@ -12,21 +12,30 @@ if [ -z "$S3BUCKET" ]; then
   echo "S3BUCKET must be set"
 fi
 
+if [ -z "$DATEFORMAT" ]; then
+  DATEFORMAT='%Y%m%d_%H%M%S'
+fi
+
+if [ -z "$FILEPREFIX" ]; then
+  FILEPREFIX=''
+fi
+
 if [ "$1" == "backup" ]; then
   echo "Starting backup..."
 
-  DATE=$(date +%Y%m%d_%H%M%S)
-  FILE='/backup/backup-$date.tar.gz'
+  DATE=$(date +$DATEFORMAT)
+  FILENAME=$FILEPREFIX$DATE.tar.gz
+  FILE=/backup/backup-$FILENAME
 
   mongodump --quiet -h $MONGO_PORT_27017_TCP_ADDR -p $MONGO_PORT_27017_TCP_PORT
   tar -zcvf $FILE dump/
-  aws s3api put-object --bucket $S3BUCKET --key $DATE.tar.gz --body $FILE
-  
-
+  aws s3api put-object --bucket $S3BUCKET --key $FILENAME --body $FILE
+  echo "Cleaning up..."
+  rm -rf dump/ $FILE
 elif [ "$1" == "list" ]; then
-	echo "Listing backups..."
+        echo "Listing backups..."
 
-	aws s3api list-objects --bucket $S3BUCKET --query 'Contents[].{Key: Key, Size: Size}' --output table
+        aws s3api list-objects --bucket $S3BUCKET --query 'Contents[].{Key: Key, Size: Size}' --output table
 else
   echo "Starting restore"
 
@@ -35,4 +44,6 @@ else
   aws s3api get-object --bucket $S3BUCKET --key $FILE /backup/$FILE
   tar -zxvf /backup/$FILE -C /backup
   mongorestore -h $MONGO_PORT_27017_TCP_ADDR -p $MONGO_PORT_27017_TCP_PORT dump/
+  echo "Cleaning up..."
+  rm -rf dump/ /backup/$FILE
 fi


### PR DESCRIPTION
I wanted to keep my backup naming consistent with https://github.com/tutumcloud/dockup and more options for prefix based S3 life cycles (e.g: if I wanted to treat daily backups different to weekly).

I have also added a ``rm`` step for the dump folder and the created tar.gz's after backup or restore. This isn't needed if using ``--rm`` and calling a ``docker run`` each time, but in my use case I just use ``docker start`` so don't want files accumulating here.

Happy to add this as an environment variable if needed, like if someone wants the docker volume to retain old backups.

Also tidied up the README a bit.

Please let me know if there is anything you want me to change.

On a side note, I like that this repo hasn't tried to integrate cron - I feel this should be in a dedicated container or as part of the host system.